### PR TITLE
Add Kubernetes Deployment Manifests for Development Environment

### DIFF
--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pingpong-app
+  namespace: pingpong-dev
+  labels:
+    app: pingpong-tracker
+    environment: development
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pingpong-tracker
+  template:
+    metadata:
+      labels:
+        app: pingpong-tracker
+    spec:
+      containers:
+      - name: pingpong-app
+        image: pipelinedave/ping-pong-tracker-preview:latest
+        ports:
+        - containerPort: 4173
+        env:
+        - name: NODE_ENV
+          value: "development"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "250m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"

--- a/kubernetes/ingress.yml
+++ b/kubernetes/ingress.yml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pingpong-app-ingress
+  namespace: pingpong-dev
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.priority: "10"
+    kubernetes.io/ingress.class: "traefik"
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: pingpong-dev.stillon.top
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: pingpong-app-service
+            port:
+              number: 80

--- a/kubernetes/namespace.yml
+++ b/kubernetes/namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pingpong-dev
+  labels:
+    environment: development

--- a/kubernetes/service.yml
+++ b/kubernetes/service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pingpong-app-service
+  namespace: pingpong-dev
+  labels:
+    app: pingpong-tracker
+spec:
+  selector:
+    app: pingpong-tracker
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 4173
+  type: ClusterIP


### PR DESCRIPTION
This PR introduces Kubernetes deployment manifests for the Ping Pong Tracker project:

- **Namespace**: Added a namespace called `pingpong-dev` to isolate development resources.
- **Deployment**: Configured the application deployment with 2 replicas and resource limits to run in the dev environment.
- **Service**: Created a ClusterIP service to expose the application internally.
- **Ingress**: Configured Traefik ingress to route external traffic to the service.

This setup allows us to run the application on the existing K3s cluster (`bigboi`) in a separate development namespace, ensuring isolation from production workloads. 
