### PR TITLE
Add CI/CD Pipeline with Docker Build and ArgoCD Integration

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,78 @@
+name: 🛠️ CI/CD Pipeline for Ping Pong Tracker 🏓
+
+on:
+  push:
+    branches:
+      - main  # Dev environment
+    tags:
+      - 'v*.*.*'  # Prod environment, tagged releases
+
+jobs:
+  build-and-push:
+    name: 🚀 Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📂 Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: 🔧 Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: 📦 Install Dependencies
+        run: yarn install
+
+      - name: 🏗️ Build Application
+        run: |
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            yarn build:dev
+          else
+            yarn build:prod
+          fi
+
+      - name: 🔐 Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: 🐳 Build Docker Image
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            docker build -t pipelinedave/ping-pong-tracker:dev-latest .
+          else
+            docker build -t pipelinedave/ping-pong-tracker:prod-latest .
+          fi
+
+      - name: 📤 Push Docker Image
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            docker push pipelinedave/ping-pong-tracker:dev-latest
+          else
+            docker push pipelinedave/ping-pong-tracker:prod-latest
+          fi
+
+  update-manifests:
+    name: ✏️ Update Kubernetes Manifests
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: 📂 Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: 🔄 Update Kubernetes Manifests with New Image
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            sed -i 's|image: pipelinedave/ping-pong-tracker:.*|image: pipelinedave/ping-pong-tracker:dev-latest|' kubernetes/dev/deployment.yaml
+          else
+            sed -i 's|image: pipelinedave/ping-pong-tracker:.*|image: pipelinedave/ping-pong-tracker:prod-latest|' kubernetes/prod/deployment.yaml
+
+      - name: 📬 Commit and Push Manifest Changes
+        run: |
+          git config --global user.email "ci-bot@pingpong.com"
+          git config --global user.name "CI Bot"
+          git add kubernetes/dev/deployment.yaml
+          git commit -m "Update dev deployment to use image: dev-latest"
+          git push origin ${{ github.ref }}

--- a/kubernetes/argocd-app-pingpong-dev.yaml
+++ b/kubernetes/argocd-app-pingpong-dev.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pingpong-dev
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/GOSCHEN/ping-pong-tracker.git' 
+    targetRevision: HEAD 
+    path: kubernetes/dev
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: pingpong-dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+


### PR DESCRIPTION
This PR introduces a fully automated CI/CD pipeline for the Ping Pong Tracker project using GitHub Actions and ArgoCD.

Key features:
- **GitHub Actions Workflow**:
  - Builds the Docker image upon commits to the `main` or `devops/docker` branches.
  - Tags and pushes the Docker image to Docker Hub with separate tags for development and production (`dev-latest` and `prod-latest`).
  - Automatically updates Kubernetes manifests with the new Docker image tag.
- **ArgoCD Application Manifest**:
  - ArgoCD is configured to automatically sync the `pingpong-dev` environment using manifests stored in the repository.
  
Please review the changes and let me know if any adjustments are needed before merging!
